### PR TITLE
Update apiconfig.py

### DIFF
--- a/facebook_business/apiconfig.py
+++ b/facebook_business/apiconfig.py
@@ -19,7 +19,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 ads_api_config = {
-  'API_VERSION': 'v8.0',
-  'SDK_VERSION': 'v8.0.6',
+  'API_VERSION': 'v9.0',
+  'SDK_VERSION': 'v9.0.0',
   'STRICT_MODE': False
 }


### PR DESCRIPTION
Though version 8.0 is not meant to be deprecated until November 1, 2022 but it currently is.

https://developers.facebook.com/docs/graph-api/changelog

The current version of the sdk uses v8.0 and returns the following error
```
 "error": {
 "message": "(#2635) You are calling a deprecated version of the Ads API. Please update to the latest version: v9.0.",
"type": "OAuthException",
 "code": 2635,
 "fbtrace_id": "AUUx3thh_PzF3igmS5SLV0R"
}
```

The ideal solution will be to undeprecate v8.0 until the proposes date. November 1, 2022